### PR TITLE
 Support loading custom env/robot modules outside the ManiSkill package

### DIFF
--- a/vr_teleop/configs/config.py
+++ b/vr_teleop/configs/config.py
@@ -1,7 +1,9 @@
+import importlib.util
 import os
+import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Type, TypeVar
+from typing import Any, Dict, Iterable, Type, TypeVar
 import mani_skill
 import tyro
 import yaml
@@ -41,6 +43,41 @@ def _add_maniskill_cache_env():
         mani_skill_cache = os.path.expanduser("~/.maniskill/data")
         print(f"MANISKILL_CACHE is set to {mani_skill_cache}, you can modify this behavior in miniussd.assets.py")
         os.environ["MANISKILL_CACHE"] = str(mani_skill_cache)
+
+
+_LOADED_MODULES: set[str] = set()
+
+
+def _load_modules(paths: Iterable[str | Path], base_path: str | Path | None = None) -> None:
+    """Import Python modules from file paths for their side effects.
+
+    These are listed under the ``_include_`` key of a config yaml. Importing them
+    triggers registration code (e.g. ManiSkill's ``@register_agent()``) so that the
+    referenced robots/environments are available when the config is built.
+
+    Paths may be absolute or relative to ``base_path`` (the including yaml file).
+    Each path is imported at most once per process.
+    """
+    for raw_path in paths:
+        path = Path(raw_path).expanduser()
+        if not path.is_absolute() and base_path is not None:
+            path = Path(base_path).parent / path
+        path = path.resolve()
+
+        key = str(path)
+        if key in _LOADED_MODULES:
+            continue
+        if not path.exists():
+            raise FileNotFoundError(f"_include_ module not found: {path}")
+
+        module_name = f"_included_{path.stem}"
+        spec = importlib.util.spec_from_file_location(module_name, key)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Could not load module from {path}")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        _LOADED_MODULES.add(key)
 
 
 _add_assets_env()
@@ -105,6 +142,10 @@ class Config:
     def from_yaml(cls: Type[T], path: str) -> T:
         cfg = OmegaConf.load(path)
         cfg_dict = OmegaConf.to_container(cfg, resolve=True)
+        # import any _include_ python modules for their side effects (e.g. agent registration)
+        includes = cfg_dict.pop("_include_", None)
+        if includes:
+            _load_modules(includes, base_path=path)
         # recursively load sub-paths
         cfg_dict = recursive_load_paths(cfg_dict, path)
         return cls.from_dict(cfg_dict)

--- a/vr_teleop/tools.py
+++ b/vr_teleop/tools.py
@@ -146,8 +146,15 @@ class replay(TaskConfig):
     """Number of environments to run to replay trajectories. With CPU backends typically this is parallelized via python multiprocessing.
     For parallelized simulation backends like physx_gpu, this is parallelized within a single python process by leveraging the GPU."""
 
+    include: Annotated[list[str], tyro.conf.arg(aliases=["-i"])] = field(default_factory=list)
+    """Python files to import before replaying, for their registration side effects
+    (e.g. ManiSkill's @register_agent() / @register_env()). Needed when the trajectory
+    uses a custom robot/env such as 3rd_party/dexmanip/robots/floating_sharpa.py.
+    Pass one or more paths, e.g. -i path/to/robot.py path/to/env.py."""
+
     def run(self, path: Path):
-        cmd = [sys.executable, "-m", "mani_skill.trajectory.replay_trajectory"]
+        # Build the arguments passed to mani_skill's replay_trajectory.
+        cmd = []
 
         # Build command with all arguments
         cmd.extend(["--traj-path", str(path)])
@@ -191,10 +198,32 @@ class replay(TaskConfig):
         if self.record_rewards:
             cmd.append("--record-rewards")
 
+        # Choose how to launch replay_trajectory. When extra modules need to be
+        # imported for their registration side effects, they must be imported in
+        # the *subprocess* (the parent process importing them has no effect), so we
+        # use a `-c` bootstrap that imports each file by path before calling main().
+        if self.include:
+            includes = [str(Path(p).expanduser().resolve()) for p in self.include]
+            for p in includes:
+                if not Path(p).exists():
+                    raise FileNotFoundError(f"--include module not found: {p}")
+            bootstrap = (
+                "import importlib.util, os, sys\n"
+                f"for p in {includes!r}:\n"
+                "    spec = importlib.util.spec_from_file_location('_inc_' + os.path.basename(p), p)\n"
+                "    m = importlib.util.module_from_spec(spec)\n"
+                "    spec.loader.exec_module(m)\n"
+                "from mani_skill.trajectory.replay_trajectory import main, parse_args\n"
+                "main(parse_args(sys.argv[1:]))\n"
+            )
+            full_cmd = [sys.executable, "-c", bootstrap] + cmd
+        else:
+            full_cmd = [sys.executable, "-m", "mani_skill.trajectory.replay_trajectory"] + cmd
+
         # Execute
         try:
-            print(f"Running: {' '.join(cmd)}")
-            subprocess.run(cmd, check=True)
+            print(f"Running: {' '.join(full_cmd)}")
+            subprocess.run(full_cmd, check=True)
             print("Replay completed!")
         except subprocess.CalledProcessError as e:
             print(f"Replay failed: {e}")


### PR DESCRIPTION
## Summary

ManiSkill discovers environments and robots through registration decorators (@register_env / @register_agent) that only execute when the defining module is imported. Custom robots/envs living outside the mani_skill package were therefore invisible to both the env builder and trajectory replay. This PR adds two mechanisms to import such modules for their registration side effects.

## Changes

- Config (vr_teleop/configs/config.py) — `Config.from_yaml` now has a top-level `_include_` key listing Python files to import before the config is built. Imports are handled by a new `_load_modules()` helper: paths may be absolute or relative to the yaml file, and each is imported at most once per process.
- Replay (vr_teleop/tools.py) — the replay task gains a `-i/--include` argument accepting one or more files. Each path is existence-checked first.

## Usage

Env config: import a custom env/robot by path:
```
_type_: maniskill_env
_include_:
  - "/abs/path/3rd_party/dexmanip/robots/tianji_sharpa.py"
  - "/abs/path/3rd_party/dexmanip/envs/insert_flower.py"
config:
  env_name: InsertFlower-v2
  robot_uids: "tianji_sharpa_hand_right"
  ...
```

Replay: pass the same files via `-i`:
```
python tools.py replay records/maniskill/InsertFlower-v1/20260629-103754/trajectory.h5 \
    -i /abs/path/3rd_party/dexmanip/robots/tianji_sharpa.py \
       /abs/path/3rd_party/dexmanip/envs/insert_flower.py
```